### PR TITLE
Migrate from ThirdPartyResource -> CustomResourceDefinition

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,32 +51,36 @@ thresholds and requirements declared in the `AppMonitor` onto the Pod.
         - name: memhog
           image: quay.io/metral/memhog:v0.0.1
           imagePullPolicy: Always
-          resources:
+          <b>resources:
             limits:
               memory: 384Mi
             requests:
-              memory: 256Mi
+              memory: 256Mi</b>
           ...
   </code></pre>
 
-* The Pod runs with a default set of resource requests & limits.
+* Run the annotated Pod, noting the resource requests & limits set that are
+also required by the Operator.
 
 * In the Pod's namespace there must also be an instantiated object of the custom
-`AppMonitor` CRD that the operator depends on e.g.:
+`AppMonitor` CRD that the Operator depends on. For example, this `AppMonitor`
+states that any Pod being monitored by the `memhog-operator` will have its
+resources doubled when 75% or more of its memory has been used e.g.:
 
   ```
   apiVersion: kubedemo.com/v1
   kind: AppMonitor
   metadata:
-    name: mymonitor
+    name: johnny-cache
   spec:
     memThresholdPercent: 75   # Percentage of (memory used) / (memory limit)
     memMultiplier: 2          # Multiplier factor used to increase memory resource requests & limits
   ```
 * The `memhog-operator` will watch the Pod's memory usage by querying
-Prometheus, apply the `AppMonitor` to the Pod as memory usage is retrieved, and redeploy the Pod 
-with higher resource requests & limits if the `AppMonitor` thresholds are crossed.
-* If the Pod is redeployed, it will have updated resource requests & limits
+Prometheus, applying the `AppMonitor` to the Pod as memory usage is retrieved.  If the `AppMonitor` threshold is crossed,
+the Operator will redeploy the Pod with higher resource requests & limits based
+on the multiplier.
+* If the Pod is redeployed, it will have updated and increased resource requests & limits
 e.g.:
 ```
   ...

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The controller watches a Namespace for an `AppMonitor`, and for Pods that wish
 to be monitored (via Annotation). It then applies the operational
 thresholds and requirements declared in the `AppMonitor` onto the Pod.
 
+## Requirements
+* Kubernetes v1.7.0+
+* Prometheus on k8s with cAdvisor exposing `container_memory_usage_bytes`
+
 ## Process
 
 * To monitor the Pod's resource memory consumption, the operator requires that the Pod have an annotation in its `spec.template.metadata` to associate itself with the `memhog-operator`.

--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ threshold, it will be vertically autoscaled by the operator.
 Specifically, the operator will deploy a new copy of the Pod with a higher
 set of resource requests and limit, and then terminate the original Pod.
 The details of the higher resources are held within an `AppMonitor`,
-a custom TPR.
+a [CustomResourceDefinition
+(CRD)](https://github.com/kubernetes/apiextensions-apiserver/blob/fbe70034cb9becd97bf8b6207f918c73cadd330e/pkg/apis/apiextensions/types.go#L119-L129).
 
 [memhog](https://github.com/metral/memhog): An example Pod that this operator would monitor.
 
-> Note: The `memhog-operator` is strictly for demo purposes. It is not intended
+> Note: The `memhog-operator` is strictly for educational & demo purposes. It is not intended
 to be used for any other use-cases.
 
 ## Operator Structure
 
-The `memhog-operator` is a combination of a custom ThirdPartyResource (TPR)
-known as the `AppMonitor`, and a custom controller to enforce state.
+The `memhog-operator` is a combination of a CustomResourceDefinition
+known as the `AppMonitor`, and a custom Controller to enforce state.
 
 The `AppMonitor` encapsulates the autoscaling details for a Pod.
 The controller watches a Namespace for an `AppMonitor`, and for Pods that wish 
@@ -61,7 +62,7 @@ thresholds and requirements declared in the `AppMonitor` onto the Pod.
 * The Pod runs with a default set of resource requests & limits.
 
 * In the Pod's namespace there must also be an instantiated object of the custom
-`AppMonitor` TPR that the operator depends on e.g.:
+`AppMonitor` CRD that the operator depends on e.g.:
 
   ```
   apiVersion: kubedemo.com/v1
@@ -107,7 +108,7 @@ $ $GOPATH/bin/memhog-operator -v2 --prometheus-addr=http://localhost:9090 --kube
 > Note: Prometheus is assumed to be running by default on http://prometheus.tectonic-system:9090 (e.g. Tectonic Cluster) by the Operator Deployment
 
 ```
-// Create cluster role & cluster role binding to work with TPR's.
+// Create cluster role & cluster role binding to work with CRD's.
 $ kubectl create -f k8s/roles/role.yaml
 
 $ kubectl create -f k8s/deploy/memhog-operator-deploy.yaml

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7c957452876f6483a63177dae7a51ee75e301053e5339a3480f8c8f58b7f75fa
-updated: 2017-07-13T07:25:17.413672205Z
+hash: 24536a63ff3daf91156dfe0fc8be4071e74f4ee5e71fa552f66cc15c54f6a8a1
+updated: 2017-07-14T00:57:19.913708437Z
 imports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
@@ -13,8 +13,8 @@ imports:
 - name: github.com/emicklei/go-restful
   version: 09691a3b6378b740595c1002f40c34dd5f218a22
   subpackages:
-  - log
   - swagger
+  - log
 - name: github.com/emicklei/go-restful-swagger12
   version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/ghodss/yaml
@@ -82,7 +82,7 @@ imports:
   - jlexer
   - jwriter
 - name: github.com/prometheus/client_golang
-  version: e7e903064f5e9eb5da98208bae10b475d4db0f8c
+  version: 95b6848b5c5bb71e3f68cd512ae5a8153c35e41f
   subpackages:
   - api
   - api/prometheus/v1
@@ -160,59 +160,72 @@ imports:
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+- name: k8s.io/apiextensions-apiserver
+  version: fbe70034cb9becd97bf8b6207f918c73cadd330e
+  subpackages:
+  - pkg/client/clientset/clientset
+  - pkg/apis/apiextensions/v1beta1
+  - pkg/apis/apiextensions
+  - pkg/client/clientset/clientset/typed/apiextensions/v1beta1
+  - pkg/client/clientset/clientset/scheme
 - name: k8s.io/apimachinery
   version: abe34e4f5b4413c282a83011892cbeea5b32223b
   subpackages:
-  - pkg/api/equality
   - pkg/api/errors
-  - pkg/api/meta
   - pkg/api/resource
-  - pkg/apimachinery
-  - pkg/apimachinery/announced
-  - pkg/apimachinery/registered
   - pkg/apis/meta/v1
-  - pkg/apis/meta/v1/unstructured
-  - pkg/apis/meta/v1alpha1
-  - pkg/conversion
-  - pkg/conversion/queryparams
-  - pkg/conversion/unstructured
-  - pkg/fields
-  - pkg/labels
-  - pkg/openapi
   - pkg/runtime
   - pkg/runtime/schema
   - pkg/runtime/serializer
+  - pkg/util/runtime
+  - pkg/watch
+  - pkg/util/wait
+  - pkg/util/validation/field
+  - pkg/openapi
+  - pkg/conversion
+  - pkg/fields
+  - pkg/labels
+  - pkg/selection
+  - pkg/types
+  - pkg/util/intstr
+  - pkg/conversion/queryparams
+  - pkg/util/errors
   - pkg/runtime/serializer/json
   - pkg/runtime/serializer/protobuf
   - pkg/runtime/serializer/recognizer
-  - pkg/runtime/serializer/streaming
   - pkg/runtime/serializer/versioning
-  - pkg/selection
-  - pkg/types
+  - pkg/util/net
+  - pkg/apimachinery/announced
+  - pkg/apimachinery/registered
+  - pkg/util/rand
+  - pkg/runtime/serializer/streaming
+  - pkg/util/sets
+  - pkg/api/meta
   - pkg/util/cache
   - pkg/util/clock
   - pkg/util/diff
-  - pkg/util/errors
-  - pkg/util/framer
-  - pkg/util/intstr
-  - pkg/util/json
-  - pkg/util/net
-  - pkg/util/rand
-  - pkg/util/runtime
-  - pkg/util/sets
   - pkg/util/validation
-  - pkg/util/validation/field
-  - pkg/util/wait
+  - third_party/forked/golang/reflect
+  - pkg/util/framer
   - pkg/util/yaml
   - pkg/version
-  - pkg/watch
-  - third_party/forked/golang/reflect
+  - pkg/apimachinery
+  - pkg/apis/meta/v1/unstructured
+  - pkg/apis/meta/v1alpha1
+  - pkg/conversion/unstructured
+  - pkg/util/json
+  - pkg/api/equality
 - name: k8s.io/client-go
   version: df46f7f13b3da19b90b8b4f0d18b8adc6fbf28dc
   subpackages:
-  - discovery
   - kubernetes
-  - kubernetes/scheme
+  - pkg/api
+  - pkg/api/v1
+  - pkg/apis/extensions/v1beta1
+  - rest
+  - tools/cache
+  - tools/clientcmd
+  - discovery
   - kubernetes/typed/admissionregistration/v1alpha1
   - kubernetes/typed/apps/v1beta1
   - kubernetes/typed/authentication/v1
@@ -233,58 +246,53 @@ imports:
   - kubernetes/typed/settings/v1alpha1
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1beta1
-  - pkg/api
-  - pkg/api/v1
-  - pkg/api/v1/ref
-  - pkg/apis/admissionregistration
-  - pkg/apis/admissionregistration/v1alpha1
-  - pkg/apis/apps
-  - pkg/apis/apps/v1beta1
-  - pkg/apis/authentication
-  - pkg/apis/authentication/v1
-  - pkg/apis/authentication/v1beta1
-  - pkg/apis/authorization
-  - pkg/apis/authorization/v1
-  - pkg/apis/authorization/v1beta1
-  - pkg/apis/autoscaling
-  - pkg/apis/autoscaling/v1
-  - pkg/apis/autoscaling/v2alpha1
-  - pkg/apis/batch
-  - pkg/apis/batch/v1
-  - pkg/apis/batch/v2alpha1
-  - pkg/apis/certificates
-  - pkg/apis/certificates/v1beta1
+  - util/flowcontrol
   - pkg/apis/extensions
-  - pkg/apis/extensions/v1beta1
-  - pkg/apis/networking
-  - pkg/apis/networking/v1
-  - pkg/apis/policy
-  - pkg/apis/policy/v1beta1
-  - pkg/apis/rbac
-  - pkg/apis/rbac/v1alpha1
-  - pkg/apis/rbac/v1beta1
-  - pkg/apis/settings
-  - pkg/apis/settings/v1alpha1
-  - pkg/apis/storage
-  - pkg/apis/storage/v1
-  - pkg/apis/storage/v1beta1
   - pkg/util
   - pkg/util/parsers
   - pkg/version
-  - rest
   - rest/watch
-  - tools/auth
-  - tools/cache
-  - tools/clientcmd
   - tools/clientcmd/api
-  - tools/clientcmd/api/latest
-  - tools/clientcmd/api/v1
   - tools/metrics
   - transport
   - util/cert
-  - util/flowcontrol
+  - kubernetes/scheme
+  - pkg/apis/apps/v1beta1
+  - pkg/apis/networking
+  - tools/auth
+  - tools/clientcmd/api/latest
   - util/homedir
+  - pkg/apis/admissionregistration/v1alpha1
+  - pkg/apis/authentication/v1
+  - pkg/apis/authentication/v1beta1
+  - pkg/apis/authorization/v1
+  - pkg/apis/authorization/v1beta1
+  - pkg/apis/autoscaling/v1
+  - pkg/apis/autoscaling/v2alpha1
+  - pkg/apis/batch/v1
+  - pkg/apis/batch/v2alpha1
+  - pkg/apis/certificates/v1beta1
+  - pkg/api/v1/ref
+  - pkg/apis/policy/v1beta1
+  - pkg/apis/networking/v1
+  - pkg/apis/rbac/v1alpha1
+  - pkg/apis/rbac/v1beta1
+  - pkg/apis/settings/v1alpha1
+  - pkg/apis/storage/v1
+  - pkg/apis/storage/v1beta1
   - util/integer
+  - pkg/apis/apps
+  - tools/clientcmd/api/v1
+  - pkg/apis/admissionregistration
+  - pkg/apis/authentication
+  - pkg/apis/authorization
+  - pkg/apis/autoscaling
+  - pkg/apis/batch
+  - pkg/apis/certificates
+  - pkg/apis/policy
+  - pkg/apis/rbac
+  - pkg/apis/settings
+  - pkg/apis/storage
 - name: k8s.io/kubernetes
   version: d3ada0119e776222f11ec7945e6d860061339aad
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -39,3 +39,7 @@ import:
   - swagger
 - package: github.com/spf13/pflag
   version: master
+- package: k8s.io/apiextensions-apiserver
+  subpackages:
+  - pkg/client/clientset/clientset
+  - pkg/apis/apiextensions/v1beta1

--- a/pkg/operator/app-monitor.go
+++ b/pkg/operator/app-monitor.go
@@ -165,7 +165,7 @@ func CopyObjToAppMonitors(obj []interface{}) ([]AppMonitor, error) {
 
 /*
  Note: The following code is boilerplate code needed to satisfy the
- AppMonitor as a resource in the cluster in terms of how it expects TPR's to
+ AppMonitor as a resource in the cluster in terms of how it expects CRD's to
  be created, operate and used.
 */
 
@@ -311,7 +311,7 @@ func ListAppMonitorsWithClient(kubecfg *rest.Config, namespace string) {
 		panic(err)
 	}
 
-	// Fetch a list of our TPRs
+	// Fetch a list of our CRDs
 	appmonitorList := AppMonitorList{}
 	err = client.Get().Resource(ResourceNamePlural).Do().Into(&appmonitorList)
 	if err != nil {

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/golang/glog"
-	"github.com/metral/memhog-operator/pkg/operator/tpr"
+	"github.com/metral/memhog-operator/pkg/operator/crd"
 	"github.com/metral/memhog-operator/pkg/utils"
 	prometheusClient "github.com/prometheus/client_golang/api"
 	prometheus "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -89,13 +89,13 @@ func NewAppMonitorController(kubeconfig, namespace, prometheusAddr string) (
 		return nil, err
 	}
 
-	// Create & register the AppMonitor resource as a TPR in the cluster, if it
+	// Create & register the AppMonitor resource as a CRD in the cluster, if it
 	// doesn't exist
 	kind := reflect.TypeOf(AppMonitor{}).Name()
-	glog.V(2).Infof("Registering TPR: %s.%s | version: %s", TPRName, Domain, Version)
-	_, err = tpr.CreateCustomResourceDefinition(
+	glog.V(2).Infof("Registering CRD: %s.%s | version: %s", CRDName, Domain, Version)
+	_, err = crd.CreateCustomResourceDefinition(
 		apiextensionsClientSet,
-		TPRName,
+		CRDName,
 		Domain,
 		kind,
 		ResourceNamePlural,

--- a/pkg/operator/crd/crd.go
+++ b/pkg/operator/crd/crd.go
@@ -1,4 +1,4 @@
-package tpr
+package crd
 
 import (
 	"fmt"

--- a/pkg/operator/tpr/tpr.go
+++ b/pkg/operator/tpr/tpr.go
@@ -2,39 +2,78 @@ package tpr
 
 import (
 	"fmt"
+	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-func CreateTPR(clientSet kubernetes.Interface, name, version, desc string) (*v1beta1.ThirdPartyResource, error) {
-	// initialize third party resource if it does not exist
-	tpr, err := clientSet.Extensions().ThirdPartyResources().Get(name, metav1.GetOptions{ResourceVersion: "0"})
+func CreateCustomResourceDefinition(clientSet apiextensionsclient.Interface, name, domain, kind, resourceNamePlural, version string) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+	crdName := fmt.Sprintf("%s.%s", resourceNamePlural, domain)
+
+	// initialize the CRD if it does not exist
+	crd, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crdName, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			tpr := &v1beta1.ThirdPartyResource{
+		if apierrors.IsNotFound(err) {
+			crd := &apiextensionsv1beta1.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
+					Name: crdName,
 				},
-				Versions: []v1beta1.APIVersion{
-					{Name: version},
+				Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+					Group:   domain,
+					Version: version,
+					Scope:   apiextensionsv1beta1.NamespaceScoped,
+					Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+						Kind:   kind,
+						Plural: resourceNamePlural,
+					},
 				},
-				Description: desc,
 			}
 
-			result, err := clientSet.Extensions().ThirdPartyResources().Create(tpr)
+			result, err := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
 			if err != nil {
 				return nil, err
 			}
-			fmt.Printf("CREATED: %#v\nFROM: %#v\n", result, tpr)
+
+			fmt.Printf("CREATED: %#v\nFROM: %#v\n", result, crd)
+
+			// wait for CRD being established
+			err = wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+				crd, err = clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crdName, metav1.GetOptions{})
+				if err != nil {
+					return false, err
+				}
+				for _, cond := range crd.Status.Conditions {
+					switch cond.Type {
+					case apiextensionsv1beta1.Established:
+						if cond.Status == apiextensionsv1beta1.ConditionTrue {
+							return true, err
+						}
+					case apiextensionsv1beta1.NamesAccepted:
+						if cond.Status == apiextensionsv1beta1.ConditionFalse {
+							fmt.Printf("Name conflict: %v\n", cond.Reason)
+						}
+					}
+				}
+				return false, err
+			})
+			if err != nil {
+				deleteErr := clientSet.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(crdName, nil)
+				if deleteErr != nil {
+					return nil, utilerrors.NewAggregate([]error{err, deleteErr})
+				}
+				return nil, err
+			}
 		} else {
 			return nil, err
 		}
 	} else {
-		fmt.Printf("SKIPPING: already exists %#v\n", tpr)
+		fmt.Printf("SKIPPING: already exists %#v\n", crd)
 	}
 
-	return tpr, nil
+	return crd, nil
 }

--- a/pkg/operator/types.go
+++ b/pkg/operator/types.go
@@ -6,12 +6,12 @@ import (
 
 // #############################################################################
 
-// Note: The following code is custom settings particular to the new TPR in the
+// Note: The following code is custom settings particular to the new CRD in the
 // cluster.
 
 // #############################################################################
 
-const TPRName string = "app-monitor"
+const CRDName string = "app-monitor"
 const ResourceName string = "appmonitor"
 const ResourceNamePlural string = "appmonitors"
 const Domain string = "kubedemo.com"
@@ -29,7 +29,7 @@ type AppMonitorSpec struct {
 // #############################################################################
 
 // Note: The following code is boilerplate code needed to satisfy the
-// AppMontior as a resource in the cluster in terms of how it expects TPR's to
+// AppMontior as a resource in the cluster in terms of how it expects CRD's to
 // be created, operate and used.
 
 // #############################################################################


### PR DESCRIPTION
This PR updates the operator to instantiate and work with a CustomResourceDefinition, as ThirdPartyResources have been [deprecated](https://github.com/kubernetes/client-go/tree/master/examples/third-party-resources-deprecated).